### PR TITLE
fix: pin reviewdog version to 1.22.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Annotate diff changes using reviewdog
       if: inputs.suggest && github.event_name == 'pull_request'
-      uses: reviewdog/action-suggester@v1
+      uses: reviewdog/action-suggester@v1.22.0
       with:
         tool_name: nph
         cleanup: false


### PR DESCRIPTION
A bug was introduced in the newest version of reviewdog, as a workaround we can [pin the previous version](https://github.com/cloudposse/.github/pull/227/files)