### PR TITLE
fix: revert reviewdog workaround

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Annotate diff changes using reviewdog
       if: inputs.suggest && github.event_name == 'pull_request'
-      uses: reviewdog/action-suggester@v1.22.0
+      uses: reviewdog/action-suggester@v1
       with:
         tool_name: nph
         cleanup: false


### PR DESCRIPTION
The workaround is no longer needed as of their latest version 1.24